### PR TITLE
Remove pytest_asyncio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ ruff==0.6.3
 pytest
 pytest-cov>2.9.0
 pytest-homeassistant-custom-component>0.13.92
-pytest-asyncio==0.23.6
 ffpp==0.0.12
 aiohttp_cors


### PR DESCRIPTION
Pytest asyncio dependence is in home assistant custom component. Remove it from here to not confusing depbot.